### PR TITLE
Fix Boulder test and document repository structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS
+
+This repository contains documentation across several files:
+
+- `README.md` – overview of the tap and automation.
+- `DEVELOPMENT.md` – development environment setup and testing workflow.
+- `SPEC.md` – system architecture specification.
+- `TODO.md` – backlog and planned improvements.
+
+### Contribution guidelines
+
+- Homebrew formulas live in `Formula/`. Run `./dev-test.sh <formula>` to
+  execute style and audit checks before committing changes. `./dev-test.sh`
+  without arguments runs checks for all formulas and the tap.
+- Keep Ruby code aligned with Homebrew's style conventions.
+

--- a/Formula/boulder.rb
+++ b/Formula/boulder.rb
@@ -54,6 +54,6 @@ class Boulder < Formula
   end
 
   test do
-    assert_match "Versions:", shell_output("#{bin}/boulder --version")
+    assert_match version.to_s, shell_output("#{bin}/boulder --version")
   end
 end

--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ additional formulas outside of Homebrew core. It currently contains two formulas
   `brew style`, `brew audit`, `brew install --build-from-source`, and `brew test`,
   then merges them automatically if successful.
 
+## Documentation
+
+- `DEVELOPMENT.md` explains environment setup and local testing.
+- `SPEC.md` describes the automation architecture.
+- `TODO.md` tracks planned improvements.
+
 ## Automation details
 
 ### Livecheck strategies


### PR DESCRIPTION
## Summary
- Correct Boulder formula test to match version output
- Document where to find repo docs and contribution guidelines
- Add AGENTS instructions pointing to documentation and testing script

## Testing
- `./dev-test.sh boulder` *(fails: SSL verification error while installing bundler)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3723c6008325852b2bf9ed25bdd0