### PR TITLE
Test: Revert boulder to trigger workflow test

### DIFF
--- a/Formula/boulder.rb
+++ b/Formula/boulder.rb
@@ -2,8 +2,8 @@ class Boulder < Formula
   desc "ACME-based certificate authority, written in Go"
   homepage "https://github.com/letsencrypt/boulder"
   url "https://github.com/letsencrypt/boulder.git",
-    tag:      "v0.20250922.0",
-    revision: "ade2703c66fb2816bebc7259cab657dbd57bb9ec"
+    tag:      "v0.20250908.0",
+    revision: "3250145c2e51580da910ce45ed5f69386331bb0f"
   license "MPL-2.0"
 
   head "https://github.com/letsencrypt/boulder.git",


### PR DESCRIPTION
This reverts boulder from v0.20250922.0 back to v0.20250908.0 to test our automated update workflow. 

The workflow should:
1. Detect that boulder has an update available (v0.20250922.0)
2. Create a bump PR automatically 
3. Run validation via brew test-bot
4. Auto-merge if validation passes

This PR tests that our branch protection and validation workflow are working correctly.