### PR TITLE
Test validation workflow with boulder downgrade

### DIFF
--- a/Formula/boulder.rb
+++ b/Formula/boulder.rb
@@ -2,8 +2,8 @@ class Boulder < Formula
   desc "ACME-based certificate authority, written in Go"
   homepage "https://github.com/letsencrypt/boulder"
   url "https://github.com/letsencrypt/boulder.git",
-    tag:      "v0.20250922.0",
-    revision: "ade2703c66fb2816bebc7259cab657dbd57bb9ec"
+    tag:      "v0.20250908.0",
+    revision: "3250145c2e51580da910ce45ed5f69386331bb0f"
   license "MPL-2.0"
 
   head "https://github.com/letsencrypt/boulder.git",


### PR DESCRIPTION
This reverts boulder from v0.20250922.0 to v0.20250908.0 to test our validation workflow.

Since this is a bump-* branch, it should:
1. ✅ Trigger the validation workflow 
2. ✅ Enable auto-merge automatically
3. ✅ Run brew test-bot validation
4. ✅ Auto-merge if tests pass

This tests the complete validation and auto-merge system.