### PR TITLE
Build agent-skills-generator from go-cli subdirectory

### DIFF
--- a/Formula/agent-skills-generator.rb
+++ b/Formula/agent-skills-generator.rb
@@ -9,7 +9,9 @@ class AgentSkillsGenerator < Formula
   depends_on "go" => :build
 
   def install
-    system "go", "build", *std_go_args(ldflags: "-s -w")
+    (buildpath/"go-cli").cd do
+      system "go", "build", *std_go_args(ldflags: "-s -w")
+    end
   end
 
   test do


### PR DESCRIPTION
### Motivation
- The upstream project moved its Go module under `go-cli`, so running `go build` from the repository root now fails with `cannot find main module`, breaking the Homebrew build.

### Description
- Update `Formula/agent-skills-generator.rb` to change the `install` step to `cd` into `buildpath/"go-cli"` and run `go build` with `std_go_args` so the build runs inside the module directory.

### Testing
- Ran `ruby -c Formula/agent-skills-generator.rb` which succeeded.
- Reproduced the original failure by running `go build ./...` at the repository root which failed with `cannot find main module`.
- Cloned the upstream repo and ran `go build ./...` inside the `go-cli` subdirectory which succeeded.
- `brew style Formula/agent-skills-generator.rb` could not be run because `brew` is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c3fe828fa08325b023f4feac563f0c)